### PR TITLE
Floating-point-friendly division for div, diveq

### DIFF
--- a/cops.js
+++ b/cops.js
@@ -137,10 +137,18 @@ exports.div = cwise({
     var b = a_i
     var c = b_r
     var d = b_i
-    var w = c * c + d * d
-    var k1 = c * (a + b)
-    out_r = (k1 + b * (c - d)) / w
-    out_i = (k1 - a * (d + c)) / w
+    var e, f;
+    if( Math.abs(c) >= Math.abs(d) ) {
+      e = d/c;
+      f = c + d*e;
+      out_r = (a + b*e) / f;
+      out_i = (b - a*e) / f;
+    } else {
+      e = c/d;
+      f = c*e + d;
+      out_r = (a*e + b) / f;
+      out_i = (b*e - a) / f;
+    }
   }
 })
 
@@ -151,10 +159,18 @@ exports.diveq = cwise({
     var b = out_i
     var c = a_r
     var d = a_i
-    var w = c * c + d * d
-    var k1 = c * (a + b)
-    out_r = (k1 + b * (c - d)) / w
-    out_i = (k1 - a * (d + c)) / w
+    var e, f;
+    if( Math.abs(c) >= Math.abs(d) ) {
+      e = d/c;
+      f = c + d*e;
+      out_r = (a + b*e) / f;
+      out_i = (b - a*e) / f;
+    } else {
+      e = c/d;
+      f = c*e + d;
+      out_r = (a*e + b) / f;
+      out_i = (b*e - a) / f;
+    }
   }
 })
 

--- a/package.json
+++ b/package.json
@@ -7,16 +7,17 @@
     "test": "test"
   },
   "dependencies": {
-    "cwise": "~0.3.2",
-    "ndarray-ops": "~1.1.0"
+    "cwise": "^0.3.4",
+    "ndarray-ops": "^1.1.1"
   },
   "devDependencies": {
-    "tap": "~0.4.2",
-    "zeros": "~0.0.0",
-    "ndarray-unpack": "0.0.0"
+    "ndarray": "^1.0.16",
+    "ndarray-unpack": "^1.0.0",
+    "tape": "^4.0.0",
+    "zeros": "^1.0.0"
   },
   "scripts": {
-    "test": "tap test/*.js"
+    "test": "node test/*.js"
   },
   "repository": {
     "type": "git",
@@ -41,5 +42,10 @@
   "author": "Mikola Lysenko",
   "license": "MIT",
   "readmeFilename": "README.md",
-  "gitHead": "063dfc9cd5e196fd55ffbac9aa29173549653387"
+  "gitHead": "063dfc9cd5e196fd55ffbac9aa29173549653387",
+  "browserify": {
+    "transform": [
+      "cwise"
+    ]
+  }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -6,7 +6,9 @@ var ops = require("ndarray-ops")
 var zeros = require("zeros")
 var unpack = require("ndarray-unpack")
 
-require("tape").test("ndarray-complex", function(t) {
+var test = require("tape");
+
+test("ndarray-complex", function(t) {
 
   var a_r = zeros([3])
     , a_i = zeros([3])
@@ -36,3 +38,58 @@ require("tape").test("ndarray-complex", function(t) {
 
   t.end()
 })
+
+test("diveq",function(t) {
+  var a_r = ndarray([1,1]),
+      a_i = ndarray([2,2]),
+      b_r = ndarray([3,3]),
+      b_i = ndarray([4,4]),
+      c_r = zeros([3]),
+      c_i = zeros([3]);
+
+  cops.diveq(a_r, a_i, b_r, b_i);
+
+  t.assert( Math.abs(a_r.get(0) - 0.44 ) < 1e-8 );
+  t.assert( Math.abs(a_i.get(0) - 0.08 ) < 1e-8 );
+  t.assert( Math.abs(a_r.get(1) - 0.44 ) < 1e-8 );
+  t.assert( Math.abs(a_i.get(1) - 0.08 ) < 1e-8 );
+
+  t.end();
+
+});
+
+test("diveq",function(t) {
+  var a_r = ndarray([1,1]),
+      a_i = ndarray([2,2]),
+      b_r = ndarray([3,3]),
+      b_i = ndarray([4,4]);
+
+  cops.diveq(a_r, a_i, b_r, b_i);
+
+  t.assert( Math.abs(a_r.get(0) - 0.44 ) < 1e-8 );
+  t.assert( Math.abs(a_i.get(0) - 0.08 ) < 1e-8 );
+  t.assert( Math.abs(a_r.get(1) - 0.44 ) < 1e-8 );
+  t.assert( Math.abs(a_i.get(1) - 0.08 ) < 1e-8 );
+
+  t.end();
+
+});
+
+test("div",function(t) {
+  var a_r = ndarray([1,1]),
+      a_i = ndarray([2,2]),
+      b_r = ndarray([3,3]),
+      b_i = ndarray([4,4]),
+      c_r = zeros([3]),
+      c_i = zeros([3]);
+
+  cops.div(c_r, c_i, a_r, a_i, b_r, b_i);
+
+  t.assert( Math.abs(c_r.get(0) - 0.44 ) < 1e-8 );
+  t.assert( Math.abs(c_i.get(0) - 0.08 ) < 1e-8 );
+  t.assert( Math.abs(c_r.get(1) - 0.44 ) < 1e-8 );
+  t.assert( Math.abs(c_i.get(1) - 0.08 ) < 1e-8 );
+
+  t.end();
+
+});

--- a/test/test.js
+++ b/test/test.js
@@ -6,7 +6,7 @@ var ops = require("ndarray-ops")
 var zeros = require("zeros")
 var unpack = require("ndarray-unpack")
 
-require("tap").test("ndarray-complex", function(t) {
+require("tape").test("ndarray-complex", function(t) {
 
   var a_r = zeros([3])
     , a_i = zeros([3])


### PR DESCRIPTION
I copy/pasted the code from my [complex-division](https://github.com/scijs/complex-division) module since I don't know how to pass two numbers from a function in javascript. Added tests also, although this module will require a huge number of tests if they're all written out like this.

This only covers two methods, but can continue to clean this up if desired. The goal is to fill in some gaps and make these basic modules fairly robust. See: mikolalysenko/ndarray-complex#3
